### PR TITLE
Fixed missing white space in install agreement.

### DIFF
--- a/src/web/assets/installer/src/install.scss
+++ b/src/web/assets/installer/src/install.scss
@@ -162,6 +162,7 @@ input.hidden {
 
   .centeralign {
     margin-top: 35px;
+    margin-bottom: 70px !important;
   }
 }
 


### PR DESCRIPTION
Fixed a missing space below the "got it" button in the license agreement.

I've attached screenshots of the before/after:

<img width="871" alt="Screenshot 2020-09-10 at 23 26 24" src="https://user-images.githubusercontent.com/1453384/92809848-48903400-f3bd-11ea-837f-4a302d3058bc.png">

<img width="914" alt="Screenshot 2020-09-10 at 23 26 41" src="https://user-images.githubusercontent.com/1453384/92809748-31514680-f3bd-11ea-8832-ee753f387efb.png">
